### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
+++ b/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
@@ -609,7 +609,7 @@ if ("undefined" == typeof jQuery)
                 for (var e = this.options.trigger.split(" "), f = e.length; f--; ) {
                     var g = e[f];
                     if ("click" == g)
-                        this.$element.on("click." + this.type, this.options.selector, a.proxy(this.toggle, this));
+                        this.$element.on("click." + this.type, this.options.selector, (this.toggle).bind(this));
                     else if ("manual" != g) {
                         var h = "hover" == g ? "mouseenter" : "focusin"
                             , i = "hover" == g ? "mouseleave" : "focusout";


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.

## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/9d5860d0-da37-4a1f-a85f-afbdca59f519/project/8a930196-ee4a-46fc-859e-6b56fec1e099/report/50b87abe-0431-4f03-ad83-cf30dfb221dc/fix/8a4f4bca-52d5-4139-ba44-8edf87f262d8)