### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
+++ b/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
@@ -146,7 +146,7 @@ if ("undefined" == typeof jQuery)
                 this.$indicators = this.$element.find(".carousel-indicators"),
                 this.options = c,
                 this.paused = this.sliding = this.interval = this.$active = this.$items = null,
-            "hover" == this.options.pause && this.$element.on("mouseenter", a.proxy(this.pause, this)).on("mouseleave", a.proxy(this.cycle, this))
+            "hover" == this.options.pause && this.$element.on("mouseenter", (this.pause).bind(this)).on("mouseleave", a.proxy(this.cycle, this))
         };
         b.DEFAULTS = {
             interval: 5e3,


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.

## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/9d5860d0-da37-4a1f-a85f-afbdca59f519/project/8a930196-ee4a-46fc-859e-6b56fec1e099/report/50b87abe-0431-4f03-ad83-cf30dfb221dc/fix/761bb1be-01f0-49f7-9fb4-05e056c36798)