### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
+++ b/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
@@ -614,7 +614,7 @@ if ("undefined" == typeof jQuery)
                         var h = "hover" == g ? "mouseenter" : "focusin"
                             , i = "hover" == g ? "mouseleave" : "focusout";
                         this.$element.on(h + "." + this.type, this.options.selector, a.proxy(this.enter, this)),
-                            this.$element.on(i + "." + this.type, this.options.selector, a.proxy(this.leave, this))
+                            this.$element.on(i + "." + this.type, this.options.selector, (this.leave).bind(this))
                     }
                 }
                 this.options.selector ? this._options = a.extend({}, this.options, {


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.

## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/9d5860d0-da37-4a1f-a85f-afbdca59f519/project/8a930196-ee4a-46fc-859e-6b56fec1e099/report/50b87abe-0431-4f03-ad83-cf30dfb221dc/fix/7f9a3651-cdd8-492f-b911-e958850470f5)