### PR TITLE
Vulnerability fix (powered by Mobb Autofixer)

### DIFF
--- a/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
+++ b/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
@@ -613,7 +613,7 @@ if ("undefined" == typeof jQuery)
                     else if ("manual" != g) {
                         var h = "hover" == g ? "mouseenter" : "focusin"
                             , i = "hover" == g ? "mouseleave" : "focusout";
-                        this.$element.on(h + "." + this.type, this.options.selector, a.proxy(this.enter, this)),
+                        this.$element.on(h + "." + this.type, this.options.selector, (this.enter).bind(this)),
                             this.$element.on(i + "." + this.type, this.options.selector, a.proxy(this.leave, this))
                     }
                 }


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.

## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/9d5860d0-da37-4a1f-a85f-afbdca59f519/project/8a930196-ee4a-46fc-859e-6b56fec1e099/report/50b87abe-0431-4f03-ad83-cf30dfb221dc/fix/f7bb7f08-6f23-469c-9f21-c6824bbdff24)