### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
+++ b/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
@@ -326,7 +326,7 @@ if ("undefined" == typeof jQuery)
                             this.transitioning = 0,
                                 this.$element.trigger("hidden.bs.collapse").removeClass("collapsing").addClass("collapse")
                         };
-                        return a.support.transition ? void this.$element[c](0).one(a.support.transition.end, a.proxy(d, this)).emulateTransitionEnd(350) : d.call(this)
+                        return a.support.transition ? void this.$element[c](0).one(a.support.transition.end, (d).bind(this)).emulateTransitionEnd(350) : d.call(this)
                     }
                 }
             }


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.

## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/9d5860d0-da37-4a1f-a85f-afbdca59f519/project/8a930196-ee4a-46fc-859e-6b56fec1e099/report/50b87abe-0431-4f03-ad83-cf30dfb221dc/fix/d032e8f3-2708-47ff-b4dd-a640405b8b20)