### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/static/plugins/bootstrap-slider/js/bootstrap-slider.js
+++ b/src/main/resources/webgoat/static/plugins/bootstrap-slider/js/bootstrap-slider.js
@@ -222,7 +222,7 @@
 				});
 			} else {
 				$(document).on({
-					mousemove: $.proxy(this.mousemove, this),
+					mousemove: (this.mousemove).bind(this),
 					mouseup: $.proxy(this.mouseup, this)
 				});
 			}


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.

## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/9d5860d0-da37-4a1f-a85f-afbdca59f519/project/8a930196-ee4a-46fc-859e-6b56fec1e099/report/50b87abe-0431-4f03-ad83-cf30dfb221dc/fix/a00f4ed0-994e-4f02-8e2d-b9fae5e706f0)