### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
+++ b/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
@@ -502,7 +502,7 @@ if ("undefined" == typeof jQuery)
                     this.escape(),
                     a(document).off("focusin.bs.modal"),
                     this.$element.removeClass("in").attr("aria-hidden", !0).off("click.dismiss.bs.modal"),
-                    a.support.transition && this.$element.hasClass("fade") ? this.$element.one(a.support.transition.end, a.proxy(this.hideModal, this)).emulateTransitionEnd(300) : this.hideModal())
+                    a.support.transition && this.$element.hasClass("fade") ? this.$element.one(a.support.transition.end, (this.hideModal).bind(this)).emulateTransitionEnd(300) : this.hideModal())
             }
             ,
             b.prototype.enforceFocus = function() {


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.

## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/9d5860d0-da37-4a1f-a85f-afbdca59f519/project/8a930196-ee4a-46fc-859e-6b56fec1e099/report/50b87abe-0431-4f03-ad83-cf30dfb221dc/fix/77da54b4-ce7e-48b0-a56b-95f850d93845)