### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
+++ b/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
@@ -923,7 +923,7 @@ if ("undefined" == typeof jQuery)
     +function(a) {
         "use strict";
         function b(c, d) {
-            var e, f = a.proxy(this.process, this);
+            var e, f = (this.process).bind(this);
             this.$element = a(a(c).is("body") ? window : c),
                 this.$body = a("body"),
                 this.$scrollElement = this.$element.on("scroll.bs.scroll-spy.data-api", f),


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.

## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/21c61d66-e044-4ac3-8065-3cd8add3080e/project/7258d132-b0e5-4eb5-9810-49191d388aec/report/49fe4244-588d-47a7-b903-946a98465120/fix/1c9210f5-778c-4ae2-99cc-f19a474aea90)