### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
+++ b/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
@@ -1071,7 +1071,7 @@ if ("undefined" == typeof jQuery)
         "use strict";
         var b = function(c, d) {
             this.options = a.extend({}, b.DEFAULTS, d),
-                this.$window = a(window).on("scroll.bs.affix.data-api", a.proxy(this.checkPosition, this)).on("click.bs.affix.data-api", a.proxy(this.checkPositionWithEventLoop, this)),
+                this.$window = a(window).on("scroll.bs.affix.data-api", (this.checkPosition).bind(this)).on("click.bs.affix.data-api", a.proxy(this.checkPositionWithEventLoop, this)),
                 this.$element = a(c),
                 this.affixed = this.unpin = this.pinnedOffset = null,
                 this.checkPosition()


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.

## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/21c61d66-e044-4ac3-8065-3cd8add3080e/project/7258d132-b0e5-4eb5-9810-49191d388aec/report/49fe4244-588d-47a7-b903-946a98465120/fix/4a78d737-e3fd-4b6e-a3e1-a64d99e9241b)