### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
+++ b/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
@@ -146,7 +146,7 @@ if ("undefined" == typeof jQuery)
                 this.$indicators = this.$element.find(".carousel-indicators"),
                 this.options = c,
                 this.paused = this.sliding = this.interval = this.$active = this.$items = null,
-            "hover" == this.options.pause && this.$element.on("mouseenter", a.proxy(this.pause, this)).on("mouseleave", a.proxy(this.cycle, this))
+            "hover" == this.options.pause && this.$element.on("mouseenter", (this.pause).bind(this)).on("mouseleave", a.proxy(this.cycle, this))
         };
         b.DEFAULTS = {
             interval: 5e3,


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.

## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/21c61d66-e044-4ac3-8065-3cd8add3080e/project/7258d132-b0e5-4eb5-9810-49191d388aec/report/49fe4244-588d-47a7-b903-946a98465120/fix/7c1e9953-7e70-4e1f-b420-ec2d50e5c288)