### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/static/plugins/bootstrap-slider/js/bootstrap-slider.js
+++ b/src/main/resources/webgoat/static/plugins/bootstrap-slider/js/bootstrap-slider.js
@@ -138,7 +138,7 @@
 
 		if (tooltip === 'show') {
 			this.picker.on({
-				mouseenter: $.proxy(this.showTooltip, this),
+				mouseenter: (this.showTooltip).bind(this),
 				mouseleave: $.proxy(this.hideTooltip, this)
 			});
 		} else {


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.

## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/21c61d66-e044-4ac3-8065-3cd8add3080e/project/7258d132-b0e5-4eb5-9810-49191d388aec/report/49fe4244-588d-47a7-b903-946a98465120/fix/73881751-fb8c-40c2-9c2d-b1f63c89c117)