### PR TITLE
Unsafe use of target blank vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/lessons/webwolfintroduction/html/WebWolfIntroduction.html
+++ b/src/main/resources/lessons/webwolfintroduction/html/WebWolfIntroduction.html
@@ -70,7 +70,7 @@
     <div class="attack-container">
         <img th:src="@{/images/wolf-enabled.png}" class="webwolf-enabled"/>
         <div class="assignment-success"><i class="fa fa-2 fa-check hidden" aria-hidden="true"></i></div>
-        <a href="WebWolf/landing/password-reset" target="_blank">Click here to reset your password</a>
+        <a href="WebWolf/landing/password-reset" rel="noopener noreferrer" target="_blank">Click here to reset your password</a>
 
         <br/>
         <br/>


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **Unsafe use of target blank** issue reported by **Checkmarx**.

## Issue description
Unsafe Target Blank occurs when developers use the target='_blank' attribute without the rel='noopener' attribute in anchor tags. This can lead to security vulnerabilities such as tabnabbing or reverse tabnabbing, allowing attackers to hijack user sessions or perform phishing attacks.
 
## Fix instructions
Ensure that anchor tags with target='_blank' attribute include the rel='noopener' attribute to prevent potential security vulnerabilities. This prevents the newly opened page from accessing the window.opener property, mitigating the risk of tabnabbing or reverse tabnabbing attacks.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/21c61d66-e044-4ac3-8065-3cd8add3080e/project/7258d132-b0e5-4eb5-9810-49191d388aec/report/49fe4244-588d-47a7-b903-946a98465120/fix/d51f2b5d-397f-465e-97a6-db5ca437e76b)