### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
+++ b/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
@@ -512,9 +512,9 @@ if ("undefined" == typeof jQuery)
             }
             ,
             b.prototype.escape = function() {
-                this.isShown && this.options.keyboard ? this.$element.on("keyup.dismiss.bs.modal", a.proxy(function(a) {
+                this.isShown && this.options.keyboard ? this.$element.on("keyup.dismiss.bs.modal", (function(a) {
                     27 == a.which && this.hide()
-                }, this)) : this.isShown || this.$element.off("keyup.dismiss.bs.modal")
+                }).bind(this)) : this.isShown || this.$element.off("keyup.dismiss.bs.modal")
             }
             ,
             b.prototype.hideModal = function() {


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.

## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/21c61d66-e044-4ac3-8065-3cd8add3080e/project/7258d132-b0e5-4eb5-9810-49191d388aec/report/49fe4244-588d-47a7-b903-946a98465120/fix/94fa0271-5a35-4673-8809-1f700813b569)