### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
+++ b/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
@@ -614,7 +614,7 @@ if ("undefined" == typeof jQuery)
                         var h = "hover" == g ? "mouseenter" : "focusin"
                             , i = "hover" == g ? "mouseleave" : "focusout";
                         this.$element.on(h + "." + this.type, this.options.selector, a.proxy(this.enter, this)),
-                            this.$element.on(i + "." + this.type, this.options.selector, a.proxy(this.leave, this))
+                            this.$element.on(i + "." + this.type, this.options.selector, (this.leave).bind(this))
                     }
                 }
                 this.options.selector ? this._options = a.extend({}, this.options, {


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.

## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/af9e0bb8-0687-4e38-805e-d352591dcdb8/project/700d9bc1-f08a-47e0-9f7b-361eb61ea308/report/e4785cb3-482d-4222-a5a8-9a0c08848345/fix/c7b783c6-ba7e-4c84-9443-749be83aaaed)