### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
+++ b/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
@@ -1090,7 +1090,7 @@ if ("undefined" == typeof jQuery)
             }
             ,
             b.prototype.checkPositionWithEventLoop = function() {
-                setTimeout(a.proxy(this.checkPosition, this), 1)
+                setTimeout((this.checkPosition).bind(this), 1)
             }
             ,
             b.prototype.checkPosition = function() {


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.

## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/b9cf1f60-bdc7-4700-b264-a555f7090c99/project/4216c16d-7dd7-4aaf-86b8-0b826c83a425/report/06737939-3948-4c39-ac2a-51284e59c6c0/fix/e7f0f5f1-41e5-4a64-8c22-e92f38cc4659)