### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
+++ b/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
@@ -1071,7 +1071,7 @@ if ("undefined" == typeof jQuery)
         "use strict";
         var b = function(c, d) {
             this.options = a.extend({}, b.DEFAULTS, d),
-                this.$window = a(window).on("scroll.bs.affix.data-api", a.proxy(this.checkPosition, this)).on("click.bs.affix.data-api", a.proxy(this.checkPositionWithEventLoop, this)),
+                this.$window = a(window).on("scroll.bs.affix.data-api", (this.checkPosition).bind(this)).on("click.bs.affix.data-api", a.proxy(this.checkPositionWithEventLoop, this)),
                 this.$element = a(c),
                 this.affixed = this.unpin = this.pinnedOffset = null,
                 this.checkPosition()


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.

JQUERY_DEPRECATED_SYMBOLS
## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/5467c457-145e-46d3-a6c9-909435bec9ee/project/26bece49-0d89-445c-a44d-e66d0d46441b/report/b6776e4c-1edc-4b4a-ba32-b62d1ad99d07/fix/2be38776-881f-4ba9-811a-b1291d3511d1)