### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
+++ b/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
@@ -502,7 +502,7 @@ if ("undefined" == typeof jQuery)
                     this.escape(),
                     a(document).off("focusin.bs.modal"),
                     this.$element.removeClass("in").attr("aria-hidden", !0).off("click.dismiss.bs.modal"),
-                    a.support.transition && this.$element.hasClass("fade") ? this.$element.one(a.support.transition.end, a.proxy(this.hideModal, this)).emulateTransitionEnd(300) : this.hideModal())
+                    a.support.transition && this.$element.hasClass("fade") ? this.$element.one(a.support.transition.end, (this.hideModal).bind(this)).emulateTransitionEnd(300) : this.hideModal())
             }
             ,
             b.prototype.enforceFocus = function() {


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.

[object Object]
## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/5467c457-145e-46d3-a6c9-909435bec9ee/project/26bece49-0d89-445c-a44d-e66d0d46441b/report/b6776e4c-1edc-4b4a-ba32-b62d1ad99d07/fix/199e1a6d-3a79-4563-9353-18cb31e87908)