### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
+++ b/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
@@ -146,7 +146,7 @@ if ("undefined" == typeof jQuery)
                 this.$indicators = this.$element.find(".carousel-indicators"),
                 this.options = c,
                 this.paused = this.sliding = this.interval = this.$active = this.$items = null,
-            "hover" == this.options.pause && this.$element.on("mouseenter", a.proxy(this.pause, this)).on("mouseleave", a.proxy(this.cycle, this))
+            "hover" == this.options.pause && this.$element.on("mouseenter", a.proxy(this.pause, this)).on("mouseleave", (this.cycle).bind(this))
         };
         b.DEFAULTS = {
             interval: 5e3,


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.

This issue was found to be irrelevant to your project - Code created by tools or frameworks, not manually written.##

                        Although a fix is available, consider whether it needs to be fixed.## 
## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/5467c457-145e-46d3-a6c9-909435bec9ee/project/26bece49-0d89-445c-a44d-e66d0d46441b/report/b6776e4c-1edc-4b4a-ba32-b62d1ad99d07/fix/970c1232-9ad4-4f18-aab0-cd5df654b5e2)