### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
+++ b/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
@@ -97,11 +97,11 @@ if ("undefined" == typeof jQuery)
                 b += "Text",
                 f.resetText || d.data("resetText", d[e]()),
                     d[e](f[b] || this.options[b]),
-                    setTimeout(a.proxy(function() {
+                    setTimeout((function() {
                         "loadingText" == b ? (this.isLoading = !0,
                             d.addClass(c).attr(c, c)) : this.isLoading && (this.isLoading = !1,
                             d.removeClass(c).removeAttr(c))
-                    }, this), 0)
+                    }).bind(this), 0)
             }
             ,
             b.prototype.toggle = function() {


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.


        > [!Irrelevant Issue]
        > This issue was found to be irrelevant to your project - Code created by tools or frameworks, not manually written.

        > Although a fix is available, consider whether it needs to be fixed. 

      ## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/5467c457-145e-46d3-a6c9-909435bec9ee/project/26bece49-0d89-445c-a44d-e66d0d46441b/report/b6776e4c-1edc-4b4a-ba32-b62d1ad99d07/fix/5252749f-56a7-48f4-8fc1-d79097724dca)