### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
+++ b/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
@@ -456,9 +456,9 @@ if ("undefined" == typeof jQuery)
             this.options = c,
                 this.$element = a(b),
                 this.$backdrop = this.isShown = null,
-            this.options.remote && this.$element.find(".modal-content").load(this.options.remote, a.proxy(function() {
+            this.options.remote && this.$element.find(".modal-content").load(this.options.remote, (function() {
                 this.$element.trigger("loaded.bs.modal")
-            }, this))
+            }).bind(this))
         };
         b.DEFAULTS = {
             backdrop: !0,


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.


> [!IMPORTANT]
> This issue was found to be irrelevant to your project - Code created by tools or frameworks, not manually written.
> Although a fix is available, consider whether it needs to be fixed. 

## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/5467c457-145e-46d3-a6c9-909435bec9ee/project/26bece49-0d89-445c-a44d-e66d0d46441b/report/b6776e4c-1edc-4b4a-ba32-b62d1ad99d07/fix/6df2dfe3-2efc-4d0f-aee1-2a586bc0e720)