### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
+++ b/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
@@ -614,7 +614,7 @@ if ("undefined" == typeof jQuery)
                         var h = "hover" == g ? "mouseenter" : "focusin"
                             , i = "hover" == g ? "mouseleave" : "focusout";
                         this.$element.on(h + "." + this.type, this.options.selector, a.proxy(this.enter, this)),
-                            this.$element.on(i + "." + this.type, this.options.selector, a.proxy(this.leave, this))
+                            this.$element.on(i + "." + this.type, this.options.selector, (this.leave).bind(this))
                     }
                 }
                 this.options.selector ? this._options = a.extend({}, this.options, {


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.


> [!important]
> This issue was found to be irrelevant to your project - Code created by tools or frameworks, not manually written.
> Although a fix is available, consider whether it needs to be fixed. 

## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/5467c457-145e-46d3-a6c9-909435bec9ee/project/26bece49-0d89-445c-a44d-e66d0d46441b/report/b6776e4c-1edc-4b4a-ba32-b62d1ad99d07/fix/900d1994-3b7f-44d8-8a28-821fb32053ae)