### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
+++ b/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
@@ -923,7 +923,7 @@ if ("undefined" == typeof jQuery)
     +function(a) {
         "use strict";
         function b(c, d) {
-            var e, f = a.proxy(this.process, this);
+            var e, f = (this.process).bind(this);
             this.$element = a(a(c).is("body") ? window : c),
                 this.$body = a("body"),
                 this.$scrollElement = this.$element.on("scroll.bs.scroll-spy.data-api", f),


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.


> [!tip]
> This issue was found to be irrelevant to your project - Code created by tools or frameworks, not manually written.
> Mobb recommends to ignore this issue, however fix is available if you think differently. 

## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/5467c457-145e-46d3-a6c9-909435bec9ee/project/26bece49-0d89-445c-a44d-e66d0d46441b/report/b6776e4c-1edc-4b4a-ba32-b62d1ad99d07/fix/43a86b7f-88b2-4c1a-95e5-57523272b665)