### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
+++ b/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
@@ -502,7 +502,7 @@ if ("undefined" == typeof jQuery)
                     this.escape(),
                     a(document).off("focusin.bs.modal"),
                     this.$element.removeClass("in").attr("aria-hidden", !0).off("click.dismiss.bs.modal"),
-                    a.support.transition && this.$element.hasClass("fade") ? this.$element.one(a.support.transition.end, a.proxy(this.hideModal, this)).emulateTransitionEnd(300) : this.hideModal())
+                    a.support.transition && this.$element.hasClass("fade") ? this.$element.one(a.support.transition.end, (this.hideModal).bind(this)).emulateTransitionEnd(300) : this.hideModal())
             }
             ,
             b.prototype.enforceFocus = function() {


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.

## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](https://fe-preview-2344.mobb.dev/organization/ec7d2726-2e10-42d8-862b-683e9b5622de/project/a204c663-61b3-4c2f-90e6-78eb459f8f67/report/472d41a2-27c0-4ef5-a0ef-996c5aa13df0/fix/9aa405f4-4557-457e-8262-b2c073b69175)