### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
+++ b/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
@@ -609,7 +609,7 @@ if ("undefined" == typeof jQuery)
                 for (var e = this.options.trigger.split(" "), f = e.length; f--; ) {
                     var g = e[f];
                     if ("click" == g)
-                        this.$element.on("click." + this.type, this.options.selector, a.proxy(this.toggle, this));
+                        this.$element.on("click." + this.type, this.options.selector, (this.toggle).bind(this));
                     else if ("manual" != g) {
                         var h = "hover" == g ? "mouseenter" : "focusin"
                             , i = "hover" == g ? "mouseleave" : "focusout";


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.

## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](https://fe-preview-2344.mobb.dev/organization/d56bb455-045e-45b5-8b17-218d45824c99/project/12061929-89b7-40fc-a08f-37f1de383fd4/report/9285ba70-61a1-4dce-9994-bc5a50478688/fix/577ef80d-1c41-42a7-9d4a-b253d1e3339a)