### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
+++ b/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
@@ -146,7 +146,7 @@ if ("undefined" == typeof jQuery)
                 this.$indicators = this.$element.find(".carousel-indicators"),
                 this.options = c,
                 this.paused = this.sliding = this.interval = this.$active = this.$items = null,
-            "hover" == this.options.pause && this.$element.on("mouseenter", a.proxy(this.pause, this)).on("mouseleave", a.proxy(this.cycle, this))
+            "hover" == this.options.pause && this.$element.on("mouseenter", a.proxy(this.pause, this)).on("mouseleave", (this.cycle).bind(this))
         };
         b.DEFAULTS = {
             interval: 5e3,


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.

## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/290246a8-6c12-40f6-922d-026294a2536c/project/1998a40a-4d9b-474b-824a-0399bd9fc6ba/report/daacb50d-2f6e-483c-8de8-e134e6257fbc/fix/30d66a75-e580-4b87-bb82-0e1b6d1a3a1b)