### PR TITLE
Auto pr for HTTP_ONLY_COOKIE

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/hijacksession/HijackSessionAssignment.java
+++ b/src/main/java/org/owasp/webgoat/lessons/hijacksession/HijackSessionAssignment.java
@@ -84,6 +84,7 @@ public class HijackSessionAssignment extends AssignmentEndpoint {
 
   private void setCookie(HttpServletResponse response, String cookieValue) {
     Cookie cookie = new Cookie(COOKIE_NAME, cookieValue);
+    cookie.setHttpOnly(true);
     cookie.setPath("/WebGoat");
     cookie.setSecure(true);
     response.addCookie(cookie);

--- a/src/main/java/org/owasp/webgoat/lessons/jwt/JWTVotesEndpoint.java
+++ b/src/main/java/org/owasp/webgoat/lessons/jwt/JWTVotesEndpoint.java
@@ -134,6 +134,7 @@ public class JWTVotesEndpoint extends AssignmentEndpoint {
       response.setContentType(MediaType.APPLICATION_JSON_VALUE);
     } else {
       Cookie cookie = new Cookie("access_token", "");
+      cookie.setHttpOnly(true);
       response.addCookie(cookie);
       response.setStatus(HttpStatus.UNAUTHORIZED.value());
       response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/java/org/owasp/webgoat/lessons/jwt/JWTVotesEndpoint.java
+++ b/src/main/java/org/owasp/webgoat/lessons/jwt/JWTVotesEndpoint.java
@@ -128,6 +128,7 @@ public class JWTVotesEndpoint extends AssignmentEndpoint {
               .signWith(io.jsonwebtoken.SignatureAlgorithm.HS512, JWT_PASSWORD)
               .compact();
       Cookie cookie = new Cookie("access_token", token);
+      cookie.setHttpOnly(true);
       response.addCookie(cookie);
       response.setStatus(HttpStatus.OK.value());
       response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/java/org/owasp/webgoat/lessons/spoofcookie/SpoofCookieAssignment.java
+++ b/src/main/java/org/owasp/webgoat/lessons/spoofcookie/SpoofCookieAssignment.java
@@ -77,6 +77,7 @@ public class SpoofCookieAssignment extends AssignmentEndpoint {
   @GetMapping(path = "/SpoofCookie/cleanup")
   public void cleanup(HttpServletResponse response) {
     Cookie cookie = new Cookie(COOKIE_NAME, "");
+    cookie.setHttpOnly(true);
     cookie.setMaxAge(0);
     response.addCookie(cookie);
   }

--- a/src/main/java/org/owasp/webgoat/lessons/spoofcookie/SpoofCookieAssignment.java
+++ b/src/main/java/org/owasp/webgoat/lessons/spoofcookie/SpoofCookieAssignment.java
@@ -93,6 +93,7 @@ public class SpoofCookieAssignment extends AssignmentEndpoint {
     if (!authPassword.isBlank() && authPassword.equals(password)) {
       String newCookieValue = EncDec.encode(lowerCasedUsername);
       Cookie newCookie = new Cookie(COOKIE_NAME, newCookieValue);
+      newCookie.setHttpOnly(true);
       newCookie.setPath("/WebGoat");
       newCookie.setSecure(true);
       response.addCookie(newCookie);


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **Cookie is not HttpOnly** issue reported by **Snyk**.

## Issue description
Cookie without the 'HttpOnly' attribute can be accessed by client-side scripts, exposing them to potential XSS attacks.
 
## Fix instructions
Ensure that sensitive cookies are marked with the 'HttpOnly' attribute to prevent client-side scripts from accessing them.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/913e03d1-d4cd-4e5e-8970-2d7ed94aee63/fix/1261012d-e9f1-4a33-84bd-b1aa194fb572)
This change fixes a **low severity** (🟢) **Cookie is not HttpOnly** issue reported by **Snyk**.

## Issue description
Cookie without the 'HttpOnly' attribute can be accessed by client-side scripts, exposing them to potential XSS attacks.
 
## Fix instructions
Ensure that sensitive cookies are marked with the 'HttpOnly' attribute to prevent client-side scripts from accessing them.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/913e03d1-d4cd-4e5e-8970-2d7ed94aee63/fix/f53d114e-1970-464e-a2b3-f73119ed092a)
This change fixes a **low severity** (🟢) **Cookie is not HttpOnly** issue reported by **Snyk**.

## Issue description
Cookie without the 'HttpOnly' attribute can be accessed by client-side scripts, exposing them to potential XSS attacks.
 
## Fix instructions
Ensure that sensitive cookies are marked with the 'HttpOnly' attribute to prevent client-side scripts from accessing them.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/913e03d1-d4cd-4e5e-8970-2d7ed94aee63/fix/e1f226d5-4e02-45e2-91f2-41056460bbf3)
This change fixes a **low severity** (🟢) **Cookie is not HttpOnly** issue reported by **Snyk**.

## Issue description
Cookie without the 'HttpOnly' attribute can be accessed by client-side scripts, exposing them to potential XSS attacks.
 
## Fix instructions
Ensure that sensitive cookies are marked with the 'HttpOnly' attribute to prevent client-side scripts from accessing them.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/913e03d1-d4cd-4e5e-8970-2d7ed94aee63/fix/b516c733-cf8f-46bf-8f43-8876c029e28f)
This change fixes a **low severity** (🟢) **Cookie is not HttpOnly** issue reported by **Snyk**.

## Issue description
Cookie without the 'HttpOnly' attribute can be accessed by client-side scripts, exposing them to potential XSS attacks.
 
## Fix instructions
Ensure that sensitive cookies are marked with the 'HttpOnly' attribute to prevent client-side scripts from accessing them.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/913e03d1-d4cd-4e5e-8970-2d7ed94aee63/fix/ba8e35a3-8362-4d6c-b0e5-2528ab2af9be)

**(powered by Mobb Autofixer)**