### PR TITLE
Auto pr for HTTP_ONLY_COOKIE

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/hijacksession/HijackSessionAssignment.java
+++ b/src/main/java/org/owasp/webgoat/lessons/hijacksession/HijackSessionAssignment.java
@@ -84,6 +84,7 @@ public class HijackSessionAssignment extends AssignmentEndpoint {
 
   private void setCookie(HttpServletResponse response, String cookieValue) {
     Cookie cookie = new Cookie(COOKIE_NAME, cookieValue);
+    cookie.setHttpOnly(true);
     cookie.setPath("/WebGoat");
     cookie.setSecure(true);
     response.addCookie(cookie);

--- a/src/main/java/org/owasp/webgoat/lessons/jwt/JWTVotesEndpoint.java
+++ b/src/main/java/org/owasp/webgoat/lessons/jwt/JWTVotesEndpoint.java
@@ -133,6 +133,7 @@ public class JWTVotesEndpoint extends AssignmentEndpoint {
       response.setContentType(MediaType.APPLICATION_JSON_VALUE);
     } else {
       Cookie cookie = new Cookie("access_token", "");
+      cookie.setHttpOnly(true);
       response.addCookie(cookie);
       response.setStatus(HttpStatus.UNAUTHORIZED.value());
       response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/java/org/owasp/webgoat/lessons/jwt/JWTVotesEndpoint.java
+++ b/src/main/java/org/owasp/webgoat/lessons/jwt/JWTVotesEndpoint.java
@@ -128,6 +128,7 @@ public class JWTVotesEndpoint extends AssignmentEndpoint {
               .signWith(io.jsonwebtoken.SignatureAlgorithm.HS512, JWT_PASSWORD)
               .compact();
       Cookie cookie = new Cookie("access_token", token);
+      cookie.setHttpOnly(true);
       response.addCookie(cookie);
       response.setStatus(HttpStatus.OK.value());
       response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/java/org/owasp/webgoat/lessons/spoofcookie/SpoofCookieAssignment.java
+++ b/src/main/java/org/owasp/webgoat/lessons/spoofcookie/SpoofCookieAssignment.java
@@ -77,6 +77,7 @@ public class SpoofCookieAssignment extends AssignmentEndpoint {
   @GetMapping(path = "/SpoofCookie/cleanup")
   public void cleanup(HttpServletResponse response) {
     Cookie cookie = new Cookie(COOKIE_NAME, "");
+    cookie.setHttpOnly(true);
     cookie.setMaxAge(0);
     response.addCookie(cookie);
   }

--- a/src/main/java/org/owasp/webgoat/lessons/spoofcookie/SpoofCookieAssignment.java
+++ b/src/main/java/org/owasp/webgoat/lessons/spoofcookie/SpoofCookieAssignment.java
@@ -93,6 +93,7 @@ public class SpoofCookieAssignment extends AssignmentEndpoint {
     if (!authPassword.isBlank() && authPassword.equals(password)) {
       String newCookieValue = EncDec.encode(lowerCasedUsername);
       Cookie newCookie = new Cookie(COOKIE_NAME, newCookieValue);
+      newCookie.setHttpOnly(true);
       newCookie.setPath("/WebGoat");
       newCookie.setSecure(true);
       response.addCookie(newCookie);


### PR DESCRIPTION
This change fixes **5** issues reported by **Snyk**.
  
  
  # Cookie is not HttpOnly (5)
  
  ## Issue description
  Cookie without the 'HttpOnly' attribute can be accessed by client-side scripts, exposing them to potential XSS attacks.
   
  ## Fix instructions
  Ensure that sensitive cookies are marked with the 'HttpOnly' attribute to prevent client-side scripts from accessing them.

  
  ## Additional info and fix customization on Mobb platform
  [HTTP_ONLY_COOKIE fix 1](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/155ef379-21ed-4e87-8aad-cb05c38c93c4/fix/f0ac51a9-a8da-4c6c-850d-4be1819e8b93)  [HTTP_ONLY_COOKIE fix 2](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/155ef379-21ed-4e87-8aad-cb05c38c93c4/fix/6a93db53-9e30-4efc-97b9-30b190209255)  [HTTP_ONLY_COOKIE fix 3](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/155ef379-21ed-4e87-8aad-cb05c38c93c4/fix/3ed20df7-5b65-4d09-a25e-8108bf953879)  [HTTP_ONLY_COOKIE fix 4](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/155ef379-21ed-4e87-8aad-cb05c38c93c4/fix/162913a1-48a6-423d-822a-e2c960d9141b)  [HTTP_ONLY_COOKIE fix 5](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/155ef379-21ed-4e87-8aad-cb05c38c93c4/fix/3e57ec7f-f081-4a46-a10c-547ab6c3e5a1)
  
  
  