### PR TITLE
Auto pr for HTTP_ONLY_COOKIE

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/hijacksession/HijackSessionAssignment.java
+++ b/src/main/java/org/owasp/webgoat/lessons/hijacksession/HijackSessionAssignment.java
@@ -84,6 +84,7 @@ public class HijackSessionAssignment extends AssignmentEndpoint {
 
   private void setCookie(HttpServletResponse response, String cookieValue) {
     Cookie cookie = new Cookie(COOKIE_NAME, cookieValue);
+    cookie.setHttpOnly(true);
     cookie.setPath("/WebGoat");
     cookie.setSecure(true);
     response.addCookie(cookie);

--- a/src/main/java/org/owasp/webgoat/lessons/jwt/JWTVotesEndpoint.java
+++ b/src/main/java/org/owasp/webgoat/lessons/jwt/JWTVotesEndpoint.java
@@ -134,6 +134,7 @@ public class JWTVotesEndpoint extends AssignmentEndpoint {
       response.setContentType(MediaType.APPLICATION_JSON_VALUE);
     } else {
       Cookie cookie = new Cookie("access_token", "");
+      cookie.setHttpOnly(true);
       response.addCookie(cookie);
       response.setStatus(HttpStatus.UNAUTHORIZED.value());
       response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/java/org/owasp/webgoat/lessons/jwt/JWTVotesEndpoint.java
+++ b/src/main/java/org/owasp/webgoat/lessons/jwt/JWTVotesEndpoint.java
@@ -128,6 +128,7 @@ public class JWTVotesEndpoint extends AssignmentEndpoint {
               .signWith(io.jsonwebtoken.SignatureAlgorithm.HS512, JWT_PASSWORD)
               .compact();
       Cookie cookie = new Cookie("access_token", token);
+      cookie.setHttpOnly(true);
       response.addCookie(cookie);
       response.setStatus(HttpStatus.OK.value());
       response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/java/org/owasp/webgoat/lessons/spoofcookie/SpoofCookieAssignment.java
+++ b/src/main/java/org/owasp/webgoat/lessons/spoofcookie/SpoofCookieAssignment.java
@@ -77,6 +77,7 @@ public class SpoofCookieAssignment extends AssignmentEndpoint {
   @GetMapping(path = "/SpoofCookie/cleanup")
   public void cleanup(HttpServletResponse response) {
     Cookie cookie = new Cookie(COOKIE_NAME, "");
+    cookie.setHttpOnly(true);
     cookie.setMaxAge(0);
     response.addCookie(cookie);
   }

--- a/src/main/java/org/owasp/webgoat/lessons/spoofcookie/SpoofCookieAssignment.java
+++ b/src/main/java/org/owasp/webgoat/lessons/spoofcookie/SpoofCookieAssignment.java
@@ -93,6 +93,7 @@ public class SpoofCookieAssignment extends AssignmentEndpoint {
     if (!authPassword.isBlank() && authPassword.equals(password)) {
       String newCookieValue = EncDec.encode(lowerCasedUsername);
       Cookie newCookie = new Cookie(COOKIE_NAME, newCookieValue);
+      newCookie.setHttpOnly(true);
       newCookie.setPath("/WebGoat");
       newCookie.setSecure(true);
       response.addCookie(newCookie);


### PR DESCRIPTION
This change fixes **5** issues reported by **Snyk**.
  
  
  # Cookie is not HttpOnly (5)
  
  ## Issue description
  Cookie without the 'HttpOnly' attribute can be accessed by client-side scripts, exposing them to potential XSS attacks.
   
  ## Fix instructions
  Ensure that sensitive cookies are marked with the 'HttpOnly' attribute to prevent client-side scripts from accessing them.

  
  ## Additional info and fix customization on Mobb platform
  [HTTP_ONLY_COOKIE fix 1](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/fca815d5-5fb0-448e-89a8-6c7897ad8715/fix/b260a601-6737-4ac6-b18c-3763a3c46874)  [HTTP_ONLY_COOKIE fix 2](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/fca815d5-5fb0-448e-89a8-6c7897ad8715/fix/f953ac4a-0e0c-4abf-8eae-6256aad94789)  [HTTP_ONLY_COOKIE fix 3](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/fca815d5-5fb0-448e-89a8-6c7897ad8715/fix/14384db5-3465-4a4d-9d87-96c608060d85)  [HTTP_ONLY_COOKIE fix 4](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/fca815d5-5fb0-448e-89a8-6c7897ad8715/fix/8232b076-40a7-4048-928d-24dd4f306178)  [HTTP_ONLY_COOKIE fix 5](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/fca815d5-5fb0-448e-89a8-6c7897ad8715/fix/7c78ae7f-d2f0-4286-9896-4b557c934688)
  
  
  

**(powered by Mobb Autofixer)**