### PR TITLE
Auto pr for INSECURE_COOKIE

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/jwt/JWTVotesEndpoint.java
+++ b/src/main/java/org/owasp/webgoat/lessons/jwt/JWTVotesEndpoint.java
@@ -128,6 +128,7 @@ public class JWTVotesEndpoint extends AssignmentEndpoint {
               .signWith(io.jsonwebtoken.SignatureAlgorithm.HS512, JWT_PASSWORD)
               .compact();
       Cookie cookie = new Cookie("access_token", token);
+      cookie.setSecure(true);
       response.addCookie(cookie);
       response.setStatus(HttpStatus.OK.value());
       response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/java/org/owasp/webgoat/lessons/jwt/JWTVotesEndpoint.java
+++ b/src/main/java/org/owasp/webgoat/lessons/jwt/JWTVotesEndpoint.java
@@ -133,6 +133,7 @@ public class JWTVotesEndpoint extends AssignmentEndpoint {
       response.setContentType(MediaType.APPLICATION_JSON_VALUE);
     } else {
       Cookie cookie = new Cookie("access_token", "");
+      cookie.setSecure(true);
       response.addCookie(cookie);
       response.setStatus(HttpStatus.UNAUTHORIZED.value());
       response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/java/org/owasp/webgoat/lessons/spoofcookie/SpoofCookieAssignment.java
+++ b/src/main/java/org/owasp/webgoat/lessons/spoofcookie/SpoofCookieAssignment.java
@@ -77,6 +77,7 @@ public class SpoofCookieAssignment extends AssignmentEndpoint {
   @GetMapping(path = "/SpoofCookie/cleanup")
   public void cleanup(HttpServletResponse response) {
     Cookie cookie = new Cookie(COOKIE_NAME, "");
+    cookie.setSecure(true);
     cookie.setMaxAge(0);
     response.addCookie(cookie);
   }


### PR DESCRIPTION
This change fixes **26** issues reported by **Snyk**.
  
  
  # Cookie is not HttpOnly (5)
  
  ## Issue description
  Cookie without the 'HttpOnly' attribute can be accessed by client-side scripts, exposing them to potential XSS attacks.
   
  ## Fix instructions
  Ensure that sensitive cookies are marked with the 'HttpOnly' attribute to prevent client-side scripts from accessing them.

  
  ## Additional info and fix customization on Mobb platform
  [HTTP_ONLY_COOKIE fix 1](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/6933f258-0d67-4365-b20f-1bb29f1eeee7/fix/16144ef1-825a-43a3-b618-5427b1db6a1c)  [HTTP_ONLY_COOKIE fix 2](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/6933f258-0d67-4365-b20f-1bb29f1eeee7/fix/6a94d8db-ac9c-4014-ad84-e536d80a389d)  [HTTP_ONLY_COOKIE fix 3](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/6933f258-0d67-4365-b20f-1bb29f1eeee7/fix/b74291b0-f59e-4aa2-8cf4-a28c91fe7653)  [HTTP_ONLY_COOKIE fix 4](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/6933f258-0d67-4365-b20f-1bb29f1eeee7/fix/1afc4314-5b50-4ba1-b775-5856b6c55c83)  [HTTP_ONLY_COOKIE fix 5](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/6933f258-0d67-4365-b20f-1bb29f1eeee7/fix/67ba70c5-aaf1-464a-bb09-7de8216877c0)
  
  
  # Insecure Cookie (3)
  
  ## Issue description
  Cookies lacking the 'Secure' attribute may be transmitted over unencrypted channels. This makes them vulnerable to interception or manipulation by attackers.
   
  ## Fix instructions
  Ensure that sensitive cookies are transmitted over secure channels (e.g., HTTPS) and are marked with the 'Secure' attributes.

  
  ## Additional info and fix customization on Mobb platform
  [INSECURE_COOKIE fix 1](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/6933f258-0d67-4365-b20f-1bb29f1eeee7/fix/23196e30-a2b7-47b7-bb6f-411779f8be1a)  [INSECURE_COOKIE fix 2](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/6933f258-0d67-4365-b20f-1bb29f1eeee7/fix/18aa1a6a-247a-429b-bcdd-f7c5f934ebc9)  [INSECURE_COOKIE fix 3](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/6933f258-0d67-4365-b20f-1bb29f1eeee7/fix/2473a524-3e9c-4f7b-a055-f04487ee1445)
  
  
  # Path Traversal (13)
  
  ## Issue description
  Path Traversal AKA Directory Traversal occurs when a path coming from user input is not properly sanitized, allowing an attacker to navigate through directories beyond the intended scope. Attackers can exploit this to access sensitive files or execute arbitrary code.
   
  ## Fix instructions
  Sanitize user-supplied paths, ensuring that they are restricted to a predefined directory structure.

  
  ## Additional info and fix customization on Mobb platform
  [PT fix 1](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/6933f258-0d67-4365-b20f-1bb29f1eeee7/fix/bca192a6-8376-41cc-90b0-f68b8fbdedd4)  [PT fix 2](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/6933f258-0d67-4365-b20f-1bb29f1eeee7/fix/2db157ba-23ee-4f12-89eb-5fa66e829f83)  [PT fix 3](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/6933f258-0d67-4365-b20f-1bb29f1eeee7/fix/f3a190b1-a664-4cbe-af9f-adab1f2f56e4)  [PT fix 4](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/6933f258-0d67-4365-b20f-1bb29f1eeee7/fix/b42fcff7-d5b3-4b2c-b371-8efb3c60638d)  [PT fix 5](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/6933f258-0d67-4365-b20f-1bb29f1eeee7/fix/b47aca21-306a-448b-9d77-006df3d4ae36)  [PT fix 6](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/6933f258-0d67-4365-b20f-1bb29f1eeee7/fix/1cee2c40-b695-4aad-b3f8-0b8f8b4e1bfc)  [PT fix 7](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/6933f258-0d67-4365-b20f-1bb29f1eeee7/fix/332fad82-d2ed-43b3-ae58-559bf87c866b)  [PT fix 8](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/6933f258-0d67-4365-b20f-1bb29f1eeee7/fix/5f846feb-474e-417e-a47f-9444c235169f)  [PT fix 9](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/6933f258-0d67-4365-b20f-1bb29f1eeee7/fix/55c4be03-e99b-405f-9ebc-fb8d737dd954)  [PT fix 10](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/6933f258-0d67-4365-b20f-1bb29f1eeee7/fix/872aad14-9f96-499a-911a-3368bf3cd1df)  [PT fix 11](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/6933f258-0d67-4365-b20f-1bb29f1eeee7/fix/8b37ae2b-c0af-45fb-8fc9-c68255dafca5)  [PT fix 12](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/6933f258-0d67-4365-b20f-1bb29f1eeee7/fix/0f584fdc-d612-44b6-a8c4-59ba885540c7)  [PT fix 13](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/6933f258-0d67-4365-b20f-1bb29f1eeee7/fix/bef7a51a-723e-4562-a551-8139cf095998)
  
  
  # SQL Injection (5)
  
  ## Issue description
  SQL Injection allows attackers to execute malicious SQL queries by manipulating input data. This can result in unauthorized access to sensitive data, data manipulation, or even complete database compromise.
   
  ## Fix instructions
  Use parameterized queries or prepared statements to sanitize user input and prevent manipulation of the SQL query.

  
  ## Additional info and fix customization on Mobb platform
  [SQL_Injection fix 1](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/6933f258-0d67-4365-b20f-1bb29f1eeee7/fix/83b6fcb8-1c47-4db1-abb3-7fe0e4bc415c)  [SQL_Injection fix 2](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/6933f258-0d67-4365-b20f-1bb29f1eeee7/fix/b587b0fe-1ff3-44c3-b4e4-1f618bd3cc0c)  [SQL_Injection fix 3](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/6933f258-0d67-4365-b20f-1bb29f1eeee7/fix/d03ece9e-132f-4a68-83ae-bde889e19bed)  [SQL_Injection fix 4](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/6933f258-0d67-4365-b20f-1bb29f1eeee7/fix/cfcd3117-2918-4484-9376-65e2e53f873d)  [SQL_Injection fix 5](http://localhost:5173/organization/1f600cd5-1e14-4fa3-96f9-31c8b0bb4ac3/project/ce0536d7-3658-4923-aefc-8d4d3dd54e1e/report/6933f258-0d67-4365-b20f-1bb29f1eeee7/fix/d3122e76-b919-4971-9e2c-49b68b5e8508)
  
  
  

**(powered by Mobb Autofixer)**