### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb) JIRA-TICKET-1 

### DIFF
--- a/src/main/resources/webgoat/static/plugins/bootstrap-slider/js/bootstrap-slider.js
+++ b/src/main/resources/webgoat/static/plugins/bootstrap-slider/js/bootstrap-slider.js
@@ -139,7 +139,7 @@
 		if (tooltip === 'show') {
 			this.picker.on({
 				mouseenter: $.proxy(this.showTooltip, this),
-				mouseleave: $.proxy(this.hideTooltip, this)
+				mouseleave: (this.hideTooltip).bind(this)
 			});
 		} else {
 			this.tooltip.addClass('hide');


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.

## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/e24b56ce-daa8-434f-a280-11f652649022/project/ccde8c3b-24b0-4400-8d2f-35817d1ef7fa/report/3124b3c1-591d-458c-8a0c-60c0b2cca47c/fix/6891bc1b-9d49-49af-b7bc-bf09b8e9967a)
Your Ticket ID: JIRA-TICKET-1
