### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
+++ b/src/main/resources/webgoat/static/js/libs/bootstrap.min.js
@@ -326,7 +326,7 @@ if ("undefined" == typeof jQuery)
                             this.transitioning = 0,
                                 this.$element.trigger("hidden.bs.collapse").removeClass("collapsing").addClass("collapse")
                         };
-                        return a.support.transition ? void this.$element[c](0).one(a.support.transition.end, a.proxy(d, this)).emulateTransitionEnd(350) : d.call(this)
+                        return a.support.transition ? void this.$element[c](0).one(a.support.transition.end, (d).bind(this)).emulateTransitionEnd(350) : d.call(this)
                     }
                 }
             }


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.

## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/2e784ee1-61ff-4744-80bc-1d9ed2e51979/project/f98c08c0-6ffc-4358-ba7e-5eb0bfe7f125/report/61f88508-a77d-4a66-8924-8709b368cf31/fix/f8faac75-4dd7-4cf6-8b0c-33ccf287f582)