### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)  T-123123 

### DIFF
--- a/src/main/resources/webgoat/static/plugins/bootstrap-slider/js/bootstrap-slider.js
+++ b/src/main/resources/webgoat/static/plugins/bootstrap-slider/js/bootstrap-slider.js
@@ -138,7 +138,7 @@
 
 		if (tooltip === 'show') {
 			this.picker.on({
-				mouseenter: $.proxy(this.showTooltip, this),
+				mouseenter: (this.showTooltip).bind(this),
 				mouseleave: $.proxy(this.hideTooltip, this)
 			});
 		} else {


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.

## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/2e784ee1-61ff-4744-80bc-1d9ed2e51979/project/f98c08c0-6ffc-4358-ba7e-5eb0bfe7f125/report/61f88508-a77d-4a66-8924-8709b368cf31/fix/8003f533-baa9-4e97-80b3-a0074ab2279e) 
Your Ticket ID: T-123123
