### PR TITLE
Log Forging vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/java/org/owasp/webgoat/container/AsciiDoctorTemplateResolver.java
+++ b/src/main/java/org/owasp/webgoat/container/AsciiDoctorTemplateResolver.java
@@ -161,7 +161,7 @@ public class AsciiDoctorTemplateResolver extends FileTemplateResolver {
     } else {
       String langHeader = request.getHeader(Headers.ACCEPT_LANGUAGE_STRING);
       if (null != langHeader) {
-        log.debug("browser locale {}", langHeader);
+        log.debug("browser locale {}", String.valueOf(langHeader).replace("\n", "").replace("\r", ""));
         return langHeader.substring(0, 2);
       } else {
         log.debug("browser default english");


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **Log Forging** issue reported by **Checkmarx**.

## Issue description
Log Forging allows attackers to manipulate log files by injecting malicious content. This can be used to obfuscate attack traces or forge log entries to conceal unauthorized activities.
 
## Fix instructions
Implement proper input sanitization to remove new lines for values going to the log.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/73fd2950-bf2c-44bc-a042-12ff9cf79b22/project/40b143e7-d65c-4b8a-a516-a3eae3701338/report/8828d33e-f74b-41c1-9ba0-248a67eb0d62/fix/0eb038b3-8983-4aff-aad0-936b07412ec4)