### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/static/plugins/bootstrap-slider/js/bootstrap-slider.js
+++ b/src/main/resources/webgoat/static/plugins/bootstrap-slider/js/bootstrap-slider.js
@@ -222,7 +222,7 @@
 				});
 			} else {
 				$(document).on({
-					mousemove: $.proxy(this.mousemove, this),
+					mousemove: (this.mousemove).bind(this),
 					mouseup: (this.mouseup).bind(this)
 				});
 			}


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.

## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/73fd2950-bf2c-44bc-a042-12ff9cf79b22/project/40b143e7-d65c-4b8a-a516-a3eae3701338/report/8828d33e-f74b-41c1-9ba0-248a67eb0d62/fix/f9a7d441-5b3b-4777-a0c1-371581121135)