### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/static/plugins/bootstrap-slider/js/bootstrap-slider.js
+++ b/src/main/resources/webgoat/static/plugins/bootstrap-slider/js/bootstrap-slider.js
@@ -132,7 +132,7 @@
 			});
 		} else {
 			this.picker.on({
-				mousedown: $.proxy(this.mousedown, this)
+				mousedown: (this.mousedown).bind(this)
 			});
 		}
 


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.

## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/7ec0e0e8-7165-449c-9d48-6fb2e650657f/project/a4becd66-47ec-4b7e-a748-826f506e56a1/report/39cd4073-6dfc-4850-a254-1027499da7a0/fix/f745429c-7cfd-4db8-ad43-ddb4f8f842b2)