### PR TITLE
jQuery deprecated symbols vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/static/plugins/bootstrap-slider/js/bootstrap-slider.js
+++ b/src/main/resources/webgoat/static/plugins/bootstrap-slider/js/bootstrap-slider.js
@@ -139,7 +139,7 @@
 		if (tooltip === 'show') {
 			this.picker.on({
 				mouseenter: $.proxy(this.showTooltip, this),
-				mouseleave: $.proxy(this.hideTooltip, this)
+				mouseleave: (this.hideTooltip).bind(this)
 			});
 		} else {
 			this.tooltip.addClass('hide');


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **jQuery deprecated symbols** issue reported by **Checkmarx**.

## Issue description
JQuery Deprecated Symbols refers to the use of deprecated or removed functions, methods, or symbols in jQuery libraries. This can lead to compatibility issues, security vulnerabilities, or performance degradation in applications.
 
## Fix instructions
Replace deprecated symbols with recommended alternatives.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/8bf20158-c4d4-47f1-8ee2-e99dab61a35d/project/234cf622-6e85-445a-b02f-e803fc0cca2d/report/59159c62-f9e4-4ea9-84d0-c48d279afea7/fix/15d644e1-5e6b-4f07-82ca-81e42756574c)