### PR TITLE
Unsafe use of target blank vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/lessons/webwolfintroduction/html/WebWolfIntroduction.html
+++ b/src/main/resources/lessons/webwolfintroduction/html/WebWolfIntroduction.html
@@ -70,7 +70,7 @@
     <div class="attack-container">
         <img th:src="@{/images/wolf-enabled.png}" class="webwolf-enabled"/>
         <div class="assignment-success"><i class="fa fa-2 fa-check hidden" aria-hidden="true"></i></div>
-        <a href="WebWolf/landing/password-reset" target="_blank">Click here to reset your password</a>
+        <a href="WebWolf/landing/password-reset" rel="noopener noreferrer" target="_blank">Click here to reset your password</a>
 
         <br/>
         <br/>


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **Unsafe use of target blank** issue reported by **Checkmarx**.

## Issue description
Unsafe Target Blank occurs when developers use the target='_blank' attribute without the rel='noopener' attribute in anchor tags. This can lead to security vulnerabilities such as tabnabbing or reverse tabnabbing, allowing attackers to hijack user sessions or perform phishing attacks.
 
## Fix instructions
Ensure that anchor tags with target='_blank' attribute include the rel='noopener' attribute to prevent potential security vulnerabilities. This prevents the newly opened page from accessing the window.opener property, mitigating the risk of tabnabbing or reverse tabnabbing attacks.



[More info and fix customization are available in the Mobb platform](https://staging.mobb.dev/organization/1a9ec405-e1be-4fe7-92be-0e618a9b8f1b/project/63186876-2931-4ca7-8254-022efce300d4/report/45ea7cfe-eddc-429f-a0df-752f4255e6f2/fix/e453b357-b56f-4fa3-9a2a-6c835e7a1abb)