### PR TITLE
Cookie is not HttpOnly vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/hijacksession/HijackSessionAssignment.java
+++ b/src/main/java/org/owasp/webgoat/lessons/hijacksession/HijackSessionAssignment.java
@@ -84,6 +84,7 @@ public class HijackSessionAssignment extends AssignmentEndpoint {
 
   private void setCookie(HttpServletResponse response, String cookieValue) {
     Cookie cookie = new Cookie(COOKIE_NAME, cookieValue);
+    cookie.setHttpOnly(true);
     cookie.setPath("/WebGoat");
     cookie.setSecure(true);
     response.addCookie(cookie);


### PR DESCRIPTION
This change fixes a **medium severity** (🟡) **Cookie is not HttpOnly** issue reported by **Checkmarx**.

## Issue description
Cookie without the 'HttpOnly' attribute can be accessed by client-side scripts, exposing them to potential XSS attacks.
 
## Fix instructions
Ensure that sensitive cookies are marked with the 'HttpOnly' attribute to prevent client-side scripts from accessing them.



[More info and fix customization are available in the Mobb platform](https://app.mobb.ai/organization/f771d5a0-c1cb-42fd-a305-5878afd85750/project/fcbc4f92-5e6a-4e43-8e15-049aba0e7788/report/f4849d5c-d5e8-427a-b278-d3c3aab46389/fix/63d929a4-1d9d-40b4-b752-8474cf10e04d)