### PR TITLE
Auto pr for PT

### DIFF
--- a/src/it/java/org/owasp/webgoat/CSRFIntegrationTest.java
+++ b/src/it/java/org/owasp/webgoat/CSRFIntegrationTest.java
@@ -20,7 +20,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
 import org.owasp.webgoat.container.lessons.Assignment;
-
+import java.io.File;
+import java.net.URI;
 public class CSRFIntegrationTest extends IntegrationTest {
 
   private static final String trickHTML3 =
@@ -93,7 +94,11 @@ public class CSRFIntegrationTest extends IntegrationTest {
 
     // remove any left over html
     Path webWolfFilePath = Paths.get(webwolfFileDir);
+    ensurePathIsRelative(htmlName);
+    ensurePathIsRelative(this.getUser());
     if (webWolfFilePath.resolve(Paths.get(this.getUser(), htmlName)).toFile().exists()) {
+      ensurePathIsRelative(htmlName);
+      ensurePathIsRelative(this.getUser());
       Files.delete(webWolfFilePath.resolve(Paths.get(this.getUser(), htmlName)));
     }
 
@@ -109,6 +114,37 @@ public class CSRFIntegrationTest extends IntegrationTest {
         .response()
         .getBody()
         .asString();
+  }
+
+  private static void ensurePathIsRelative(String path) {
+    ensurePathIsRelative(new File(path));
+  }
+
+
+  private static void ensurePathIsRelative(URI uri) {
+    ensurePathIsRelative(new File(uri));
+  }
+
+
+  private static void ensurePathIsRelative(File file) {
+    // Based on https://stackoverflow.com/questions/2375903/whats-the-best-way-to-defend-against-a-path-traversal-attack/34658355#34658355
+    String canonicalPath;
+    String absolutePath;
+  
+    if (file.isAbsolute()) {
+      throw new RuntimeException("Potential directory traversal attempt - absolute path not allowed");
+    }
+  
+    try {
+      canonicalPath = file.getCanonicalPath();
+      absolutePath = file.getAbsolutePath();
+    } catch (IOException e) {
+      throw new RuntimeException("Potential directory traversal attempt", e);
+    }
+  
+    if (!canonicalPath.startsWith(absolutePath) || !canonicalPath.equals(absolutePath)) {
+      throw new RuntimeException("Potential directory traversal attempt");
+    }
   }
 
   private String callTrickHtml(String htmlName) {

--- a/src/it/java/org/owasp/webgoat/CSRFIntegrationTest.java
+++ b/src/it/java/org/owasp/webgoat/CSRFIntegrationTest.java
@@ -92,6 +92,7 @@ public class CSRFIntegrationTest extends IntegrationTest {
 
   private void uploadTrickHtml(String htmlName, String htmlContent) throws IOException {
 
+    ensurePathIsRelative(htmlName);
     // remove any left over html
     Path webWolfFilePath = Paths.get(webwolfFileDir);
     ensurePathIsRelative(htmlName);

--- a/src/main/java/org/owasp/webgoat/webwolf/FileServer.java
+++ b/src/main/java/org/owasp/webgoat/webwolf/FileServer.java
@@ -49,6 +49,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
+import java.net.URI;
 
 /** Controller for uploading a file */
 @Controller
@@ -86,12 +87,44 @@ public class FileServer {
     String username = authentication.getName();
     var destinationDir = new File(fileLocation, username);
     destinationDir.mkdirs();
+    ensurePathIsRelative(myFile.getOriginalFilename());
     myFile.transferTo(new File(destinationDir, myFile.getOriginalFilename()));
     log.debug("File saved to {}", new File(destinationDir, myFile.getOriginalFilename()));
 
     return new ModelAndView(
         new RedirectView("files", true),
         new ModelMap().addAttribute("uploadSuccess", "File uploaded successful"));
+  }
+
+  private static void ensurePathIsRelative(String path) {
+    ensurePathIsRelative(new File(path));
+  }
+
+
+  private static void ensurePathIsRelative(URI uri) {
+    ensurePathIsRelative(new File(uri));
+  }
+
+
+  private static void ensurePathIsRelative(File file) {
+    // Based on https://stackoverflow.com/questions/2375903/whats-the-best-way-to-defend-against-a-path-traversal-attack/34658355#34658355
+    String canonicalPath;
+    String absolutePath;
+  
+    if (file.isAbsolute()) {
+      throw new RuntimeException("Potential directory traversal attempt - absolute path not allowed");
+    }
+  
+    try {
+      canonicalPath = file.getCanonicalPath();
+      absolutePath = file.getAbsolutePath();
+    } catch (IOException e) {
+      throw new RuntimeException("Potential directory traversal attempt", e);
+    }
+  
+    if (!canonicalPath.startsWith(absolutePath) || !canonicalPath.equals(absolutePath)) {
+      throw new RuntimeException("Potential directory traversal attempt");
+    }
   }
 
   @GetMapping(value = "/files")


### PR DESCRIPTION
This change fixes **3** issues reported by **Opengrep**.
  
  
  # Path Traversal (3)
  
  ## Issue description
  Path Traversal AKA Directory Traversal occurs when a path coming from user input is not properly sanitized, allowing an attacker to navigate through directories beyond the intended scope. Attackers can exploit this to access sensitive files or execute arbitrary code.
   
  ## Fix instructions
  Sanitize user-supplied paths, ensuring that they are restricted to a predefined directory structure.

  
  ## Additional info and fix customization on Mobb platform
  [PT fix 1](http://localhost:5173/organization/ca2ec693-e29f-4efa-bbf1-45910a412b08/project/0020ad72-cdc1-42e2-bc22-150e22d1218f/report/059bb802-65ff-47ba-9397-aa68802f20a2/fix/71bf7044-f55e-4e3f-ac05-191b7ac4acee)  [PT fix 2](http://localhost:5173/organization/ca2ec693-e29f-4efa-bbf1-45910a412b08/project/0020ad72-cdc1-42e2-bc22-150e22d1218f/report/059bb802-65ff-47ba-9397-aa68802f20a2/fix/4cf82cb4-b582-4153-b841-e6ff35dee811)  [PT fix 3](http://localhost:5173/organization/ca2ec693-e29f-4efa-bbf1-45910a412b08/project/0020ad72-cdc1-42e2-bc22-150e22d1218f/report/059bb802-65ff-47ba-9397-aa68802f20a2/fix/6dbeda92-9fe0-4a28-9e38-19a6ee001f96)
  
  
  

**(powered by Mobb Autofixer)**