### PR TITLE
Vulnerability fix (powered by Mobb Autofixer)

### DIFF
--- a/src/main/java/org/owasp/webgoat/container/AsciiDoctorTemplateResolver.java
+++ b/src/main/java/org/owasp/webgoat/container/AsciiDoctorTemplateResolver.java
@@ -161,7 +161,7 @@ public class AsciiDoctorTemplateResolver extends FileTemplateResolver {
     } else {
       String langHeader = request.getHeader(Headers.ACCEPT_LANGUAGE_STRING);
       if (null != langHeader) {
-        log.debug("browser locale {}", langHeader);
+        log.debug("browser locale {}", String.valueOf(langHeader).replace("\n", "").replace("\r", ""));
         return langHeader.substring(0, 2);
       } else {
         log.debug("browser default english");

--- a/src/main/java/org/owasp/webgoat/webwolf/requests/LandingPage.java
+++ b/src/main/java/org/owasp/webgoat/webwolf/requests/LandingPage.java
@@ -45,7 +45,7 @@ public class LandingPage {
       })
   public Callable<ResponseEntity<?>> ok(HttpServletRequest request) {
     return () -> {
-      log.trace("Incoming request for: {}", request.getRequestURL());
+      log.trace("Incoming request for: {}", String.valueOf(request.getRequestURL()).replace("\n", "").replace("\r", ""));
       return ResponseEntity.ok().build();
     };
   }

--- a/src/main/resources/lessons/webwolfintroduction/html/WebWolfIntroduction.html
+++ b/src/main/resources/lessons/webwolfintroduction/html/WebWolfIntroduction.html
@@ -70,7 +70,7 @@
     <div class="attack-container">
         <img th:src="@{/images/wolf-enabled.png}" class="webwolf-enabled"/>
         <div class="assignment-success"><i class="fa fa-2 fa-check hidden" aria-hidden="true"></i></div>
-        <a href="WebWolf/landing/password-reset" target="_blank">Click here to reset your password</a>
+        <a href="WebWolf/landing/password-reset" rel="noopener noreferrer" target="_blank">Click here to reset your password</a>
 
         <br/>
         <br/>


### PR DESCRIPTION
This change fixes **3** issues reported by **Checkmarx**.
  
  
  # Unsafe use of target blank (1)
  
  ## Issue description
  Unsafe Target Blank occurs when developers use the target='_blank' attribute without the rel='noopener' attribute in anchor tags. This can lead to security vulnerabilities such as tabnabbing or reverse tabnabbing, allowing attackers to hijack user sessions or perform phishing attacks.
   
  ## Fix instructions
  Ensure that anchor tags with target='_blank' attribute include the rel='noopener' attribute to prevent potential security vulnerabilities. This prevents the newly opened page from accessing the window.opener property, mitigating the risk of tabnabbing or reverse tabnabbing attacks.

  
  ## Additional info and fix customization on Mobb platform
  [UNSAFE_TARGET_BLANK fix](http://localhost:5173/organization/174c179a-efb0-4559-bc50-97f0b828588d/project/b3d99fdd-96df-4980-8cf6-db7959644e3e/report/ca49266c-a183-40f3-ae2a-289d92dffdbb/fix/a4b4d887-72a1-4810-a7d7-30b061a42988)
  
  
  # Log Forging (2)
  
  ## Issue description
  Log Forging allows attackers to manipulate log files by injecting malicious content. This can be used to obfuscate attack traces or forge log entries to conceal unauthorized activities.
   
  ## Fix instructions
  Implement proper input sanitization to remove new lines for values going to the log.

  
  ## Additional info and fix customization on Mobb platform
  [LOG_FORGING fix 1](http://localhost:5173/organization/174c179a-efb0-4559-bc50-97f0b828588d/project/b3d99fdd-96df-4980-8cf6-db7959644e3e/report/ca49266c-a183-40f3-ae2a-289d92dffdbb/fix/08140424-06da-4d04-98a7-6a20f2f044a9)  [LOG_FORGING fix 2](http://localhost:5173/organization/174c179a-efb0-4559-bc50-97f0b828588d/project/b3d99fdd-96df-4980-8cf6-db7959644e3e/report/ca49266c-a183-40f3-ae2a-289d92dffdbb/fix/c654bf80-b68b-49ab-8ba4-dacb15196103)
  
  
  