### PR TITLE
Cookie is not HttpOnly vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/hijacksession/HijackSessionAssignment.java
+++ b/src/main/java/org/owasp/webgoat/lessons/hijacksession/HijackSessionAssignment.java
@@ -84,6 +84,7 @@ public class HijackSessionAssignment extends AssignmentEndpoint {
 
   private void setCookie(HttpServletResponse response, String cookieValue) {
     Cookie cookie = new Cookie(COOKIE_NAME, cookieValue);
+    cookie.setHttpOnly(true);
     cookie.setPath("/WebGoat");
     cookie.setSecure(true);
     response.addCookie(cookie);


### PR DESCRIPTION
This change fixes a **medium severity** (🟡) **Cookie is not HttpOnly** issue reported by **Checkmarx**.

## Issue description
Cookie without the 'HttpOnly' attribute can be accessed by client-side scripts, exposing them to potential XSS attacks.
 
## Fix instructions
Ensure that sensitive cookies are marked with the 'HttpOnly' attribute to prevent client-side scripts from accessing them.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/174c179a-efb0-4559-bc50-97f0b828588d/project/b3d99fdd-96df-4980-8cf6-db7959644e3e/report/ca49266c-a183-40f3-ae2a-289d92dffdbb/fix/c4929b29-b687-4035-87a9-acedf62fe6fa)