### PR TITLE
Log Forging vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/java/org/owasp/webgoat/container/AsciiDoctorTemplateResolver.java
+++ b/src/main/java/org/owasp/webgoat/container/AsciiDoctorTemplateResolver.java
@@ -161,7 +161,7 @@ public class AsciiDoctorTemplateResolver extends FileTemplateResolver {
     } else {
       String langHeader = request.getHeader(Headers.ACCEPT_LANGUAGE_STRING);
       if (null != langHeader) {
-        log.debug("browser locale {}", langHeader);
+        log.debug("browser locale {}", String.valueOf(langHeader).replace("\n", "").replace("\r", ""));
         return langHeader.substring(0, 2);
       } else {
         log.debug("browser default english");


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **Log Forging** issue reported by **Checkmarx**.

## Issue description
Log Forging allows attackers to manipulate log files by injecting malicious content. This can be used to obfuscate attack traces or forge log entries to conceal unauthorized activities.

## Fix instructions
Implement proper input sanitization to remove new lines for values going to the log.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/6e505d7a-0046-47e7-9e36-b44c80af334f/project/0039f636-0a3f-4860-86d5-0d089c2dd69f/report/8f4186a1-7d07-41cc-989c-3070e6df1527/fix/1ca02604-eddc-4383-94ae-1c0179da1817)