### PR TITLE
Unsafe use of target blank vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/lessons/webwolfintroduction/html/WebWolfIntroduction.html
+++ b/src/main/resources/lessons/webwolfintroduction/html/WebWolfIntroduction.html
@@ -70,7 +70,7 @@
     <div class="attack-container">
         <img th:src="@{/images/wolf-enabled.png}" class="webwolf-enabled"/>
         <div class="assignment-success"><i class="fa fa-2 fa-check hidden" aria-hidden="true"></i></div>
-        <a href="WebWolf/landing/password-reset" target="_blank">Click here to reset your password</a>
+        <a href="WebWolf/landing/password-reset" rel="noopener noreferrer" target="_blank">Click here to reset your password</a>
 
         <br/>
         <br/>


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **Unsafe use of target blank** issue reported by **Checkmarx**.

## Issue description
Unsafe Target Blank occurs when developers use the target='_blank' attribute without the rel='noopener' attribute in anchor tags. This can lead to security vulnerabilities such as tabnabbing or reverse tabnabbing, allowing attackers to hijack user sessions or perform phishing attacks.

## Fix instructions
Ensure that anchor tags with target='_blank' attribute include the rel='noopener' attribute to prevent potential security vulnerabilities. This prevents the newly opened page from accessing the window.opener property, mitigating the risk of tabnabbing or reverse tabnabbing attacks.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/50887153-c38c-41b0-8bc8-6897940bde19/project/7989f358-deb0-4e6b-a936-a1b91867bede/report/657dd7c1-8e5f-46fe-8e50-375eedca1097/fix/5acc2f5e-1819-4db2-9e19-afc39d43a8c3)