### PR TITLE
Cookie is not HttpOnly vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/hijacksession/HijackSessionAssignment.java
+++ b/src/main/java/org/owasp/webgoat/lessons/hijacksession/HijackSessionAssignment.java
@@ -84,6 +84,7 @@ public class HijackSessionAssignment extends AssignmentEndpoint {
 
   private void setCookie(HttpServletResponse response, String cookieValue) {
     Cookie cookie = new Cookie(COOKIE_NAME, cookieValue);
+    cookie.setHttpOnly(true);
     cookie.setPath("/WebGoat");
     cookie.setSecure(true);
     response.addCookie(cookie);


### PR DESCRIPTION
This change fixes a **medium severity** (🟡) **Cookie is not HttpOnly** issue reported by **Checkmarx**.

## Issue description
Cookie without the 'HttpOnly' attribute can be accessed by client-side scripts, exposing them to potential XSS attacks.

## Fix instructions
Ensure that sensitive cookies are marked with the 'HttpOnly' attribute to prevent client-side scripts from accessing them.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/50887153-c38c-41b0-8bc8-6897940bde19/project/7989f358-deb0-4e6b-a936-a1b91867bede/report/657dd7c1-8e5f-46fe-8e50-375eedca1097/fix/e81ed547-bbca-42a0-b323-5f3ec9c64010)