### PR TITLE
Cross-Site Request Forgery (CSRF) vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/lessons/ssrf/html/SSRF.html
+++ b/src/main/resources/lessons/ssrf/html/SSRF.html
@@ -13,6 +13,7 @@
             <form class="attack-form" accept-charset="UNKNOWN"
                   method="POST" name="form"
                   action="SSRF/task1">
+                {% csrf_token %}
                 <table>
                     <tr>
                         <td><input type="hidden" id="url1" name="url" value="images/tom.png"/></td>


### PR DESCRIPTION
This change fixes a **medium severity** (🟡) **Cross-Site Request Forgery (CSRF)** issue reported by **Opengrep**.

## Issue description
Cross Site Request Forgery is an attack that forces an end user to execute unwanted actions on a web application in which they’re currently authenticated.

## Fix instructions
Configure a CSRF protection mechanism, such as a CSRF token, in your application.

## Additional actions required
 Please make sure the CSRF middleware is activated by default in the MIDDLEWARE setting. If you override that setting, remember that `django.middleware.csrf.CsrfViewMiddleware` should come before any view middleware that assume that CSRF attacks have been dealt with.


If you disabled it, which is not recommended, you can use [`csrf_protect()`](https://docs.djangoproject.com/en/5.1/ref/csrf/#django.views.decorators.csrf.csrf_protect) annotation on this particular view.


See more information [here](https://docs.djangoproject.com/en/5.1/howto/csrf/).


[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/1b093c75-6c56-40fe-9a0d-71bf7fb615c6/project/f8c974cd-aea9-4eef-8389-30c764843101/report/a8118efa-8117-4a45-802c-0a0b557c2686/fix/f3fb3cd8-5fa5-4f69-ac0d-4b37e9f8c309)