### PR TITLE
Cross-Site Request Forgery (CSRF) vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/lessons/challenges/html/Challenge7.html
+++ b/src/main/resources/lessons/challenges/html/Challenge7.html
@@ -58,6 +58,7 @@ f94008f801fceb8833a30fe56a8b26976347edcf First version of WebGoat Cloud website
         </div>
         <br/>
         <form class="attack-form" method="POST" name="form" action="challenge/flag">
+            {% csrf_token %}
             <div class="form-group">
                 <div class="input-group">
                     <div class="input-group-addon"><i class="fa fa-flag-checkered" aria-hidden="true"


### PR DESCRIPTION
This change fixes a **medium severity** (🟡) **Cross-Site Request Forgery (CSRF)** issue reported by **Opengrep**.

## Issue description
Cross Site Request Forgery is an attack that forces an end user to execute unwanted actions on a web application in which they’re currently authenticated.

## Fix instructions
Configure a CSRF protection mechanism, such as a CSRF token, in your application.

## Additional actions required
 Please make sure the CSRF middleware is activated by default in the MIDDLEWARE setting. If you override that setting, remember that `django.middleware.csrf.CsrfViewMiddleware` should come before any view middleware that assume that CSRF attacks have been dealt with.


If you disabled it, which is not recommended, you can use [`csrf_protect()`](https://docs.djangoproject.com/en/5.1/ref/csrf/#django.views.decorators.csrf.csrf_protect) annotation on this particular view.


See more information [here](https://docs.djangoproject.com/en/5.1/howto/csrf/).


[More info and fix customization are available in the Mobb platform](https://st-stenant.mobb.dev/organization/d9e4bd39-84bb-4849-a4f7-975157cbc999/project/82541930-10a7-4729-bbba-fa882eeba4ea/report/352147c1-fac2-4214-955a-f4d1f849fc17/fix/1f18698e-a9bc-43b5-af47-4f5c2fbd3478)